### PR TITLE
Store and Clear ds_row->modified_data on update

### DIFF
--- a/ds_row.lasso
+++ b/ds_row.lasso
@@ -181,10 +181,6 @@ define ds_row => type{
 
 	// Clear out the modified_data store
 	public storeModified => {
-		local(new_cols)  = array
-		local(new_data)  = array
-		local(new_index) = .row->size
-
 		.modified_data->forEachNode2 => {
 			local(key)   = #1->key
 			local(value) = #1->value


### PR DESCRIPTION
When data is updated in the database, it calls a new method (ds_row->storeModified) to take any modified data and store it in ds_row->row, ds_row->index, and ds_row->cols. Then ds_row->modified_data is set to an empty map.
