### PR TITLE
Fixing problems when database alias doesn't match the name

### DIFF
--- a/ds.lasso
+++ b/ds.lasso
@@ -253,6 +253,8 @@ define ds => type{
 			#dsinfo->hostpassword      = #password
 			#dsinfo->hosttableencoding = #encoding
 			#dsinfo->hostschema        = #schema
+			#dsinfo->databasename      = #database
+			#dsinfo->tablename         = #table
 	
 			.'capi' = \#datasource
 			
@@ -267,24 +269,26 @@ define ds => type{
 			fail_if(!#hostinfo,'Unable to determine host for: '+#database+'.'+#table)
 			
 			//	Set properties from found info
-			#dsinfo->hostdatasource 	= #hostinfo->get(1)
-			#dsinfo->hostid 			= #hostinfo->get(2)	
-			#dsinfo->hostname 			= #hostinfo->get(3)
-			#dsinfo->hostport 			= #hostinfo->get(4)
-			#dsinfo->hostusername 		= #hostinfo->get(5)
-			#dsinfo->hostpassword		= #hostinfo->get(6)
-			#dsinfo->hostschema 		= #hostinfo->get(7)
-			#dsinfo->hosttableencoding 	= #hostinfo->get(8)||#encoding	
+			#dsinfo->hostdatasource    = #hostinfo->get(1)
+			#dsinfo->hostid            = #hostinfo->get(2)	
+			#dsinfo->hostname          = #hostinfo->get(3)
+			#dsinfo->hostport          = #hostinfo->get(4)
+			#dsinfo->hostusername      = #hostinfo->get(5)
+			#dsinfo->hostpassword      = #hostinfo->get(6)
+			#dsinfo->hostschema        = #hostinfo->get(7)
+			#dsinfo->hosttableencoding = #hostinfo->get(8)||#encoding
+			#dsinfo->databasename      = #hostinfo->get(9)
+			#dsinfo->tablename         = #table
 
 			.'capi' = \#datasource
 		else 
-			#store = false 
-		}
+			#store = false
 
-		//	Replace database and table (most likely the same unless key)
-		#dsinfo->databasename		= #database
-		#dsinfo->tablename			= #table
-		#dsinfo->maxrows 			= #maxrows
+			//	Replace database and table (most likely the same unless key)
+			#dsinfo->databasename = #database
+			#dsinfo->tablename    = #table
+		}
+		#dsinfo->maxrows = #maxrows
 
 		//	Legacy: leverage clasic inlie constructor
 		if(#useinfo) => {
@@ -335,7 +339,8 @@ define ds => type{
 			h.username,
 			h.password,
 			h.schema,
-			"" as encoding
+			"" as encoding,
+			db.name AS database
 			
 		FROM 	datasources AS ds,
 				datasource_hosts AS h, 
@@ -360,7 +365,8 @@ define ds => type{
 			h.username,
 			h.password,
 			h.schema,
-			tb.encoding
+			tb.encoding,
+			db.name AS database
 			
 		FROM 	datasources AS ds,
 				datasource_hosts AS h, 

--- a/ds.lasso
+++ b/ds.lasso
@@ -241,7 +241,10 @@ define ds => type{
 		if(.primed) => { 
 			
 			// Reusing details + connection (if active)
-			#store = false 
+			#store = false
+			//	Replace database and table (most likely the same unless key)
+			#dsinfo->databasename = #database
+			#dsinfo->tablename    = #table
 
 		else(#host)			
 			//	Host specified, skip look up — fast

--- a/ds.lasso
+++ b/ds.lasso
@@ -448,6 +448,8 @@ define ds => type{
 			#dsinfo->hostpassword      = #d->hostpassword
 			#dsinfo->hosttableencoding = #d->hosttableencoding
 			#dsinfo->hostschema        = #d->hostschema
+			#dsinfo->databasename      = #d->databasename
+			#dsinfo->tablename         = #d->tablename
 
 			#dsinfo->connection = #d->connection
 			#dsinfo->prepared   = #d->prepared

--- a/ds.lasso
+++ b/ds.lasso
@@ -278,7 +278,7 @@ define ds => type{
 			#dsinfo->hostschema        = #hostinfo->get(7)
 			#dsinfo->hosttableencoding = #hostinfo->get(8)||#encoding
 			#dsinfo->databasename      = #hostinfo->get(9)
-			#dsinfo->tablename         = #table
+			#dsinfo->tablename         = #hostinfo->get(10)||#table
 
 			.'capi' = \#datasource
 		else 
@@ -340,7 +340,8 @@ define ds => type{
 			h.password,
 			h.schema,
 			"" as encoding,
-			db.name AS database
+			db.name AS database,
+			"" as table
 			
 		FROM 	datasources AS ds,
 				datasource_hosts AS h, 
@@ -366,7 +367,8 @@ define ds => type{
 			h.password,
 			h.schema,
 			tb.encoding,
-			db.name AS database
+			db.name AS database,
+			tb.name AS table
 			
 		FROM 	datasources AS ds,
 				datasource_hosts AS h, 


### PR DESCRIPTION
When looking up a database from the SQLite tables, DS does look up by the alias.
Unfortunately, it uses the alias name as the database name when storing the
information into dsinfo. This means that if the alias name is not the same as
the database name, queries will produce "1046: No database selected" errors.

This commit fixes this issue by making sure that the database name is pulled
from the "name" field from the "datasource_databases" table.
